### PR TITLE
Add API key resource links

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -57,6 +57,26 @@
               </div>
             </div>
 
+            <p class="text-sm text-gray-500 mt-2">
+              Get API keys from
+              <a
+                href="https://ai.dev"
+                class="text-blue-600 underline"
+                target="_blank"
+                rel="noopener"
+                >Google AI Studio</a
+              >
+              or
+              <a
+                href="https://platform.openai.com/api-keys"
+                class="text-blue-600 underline"
+                target="_blank"
+                rel="noopener"
+                >OpenAI</a
+              >
+              .
+            </p>
+
             <div class="mt-4">
               <label class="block text-sm font-medium text-gray-700 mb-2">
                 API Key <span id="apiKeyLabel">(OpenAI)</span>


### PR DESCRIPTION
## Summary
- provide links for API key signup to OpenAI and Google AI Studio below the AI provider dropdown

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f74effa4c832db8836a2084db1e51